### PR TITLE
fast indexing for large matrix

### DIFF
--- a/fastl2lir/fastl2lir.py
+++ b/fastl2lir/fastl2lir.py
@@ -174,7 +174,8 @@ class FastL2LiR(object):
                         I = I[::-1]
                         I = I[0:n_feat]
                         I = np.hstack((I, X.shape[1]-1))
-                        Wb = np.linalg.solve(W0[I][:, I], W1[index_outputDim][I].reshape(-1,1))
+                        W0_sub = (W0.ravel()[(I + (I * W0.shape[1]).reshape((-1,1))).ravel()]).reshape(I.size, I.size)
+                        Wb = np.linalg.solve(W0_sub, W1[index_outputDim][I].reshape(-1,1))
                         for index_selectedDim in range(n_feat):
                             W[index_outputDim, I[index_selectedDim]] = Wb[index_selectedDim]
                         b[0, index_outputDim] = Wb[-1]
@@ -186,7 +187,8 @@ class FastL2LiR(object):
                     I = I[::-1]
                     I = I[0:n_feat]
                     I = np.hstack((I, X.shape[1]-1))
-                    Wb = np.linalg.solve(W0[I][:, I], W1[index_outputDim][I].reshape(-1,1))
+                    W0_sub = (W0.ravel()[(I + (I * W0.shape[1]).reshape((-1,1))).ravel()]).reshape(I.size, I.size)
+                    Wb = np.linalg.solve(W0_sub, W1[index_outputDim][I].reshape(-1,1))
                     for index_selectedDim in range(n_feat):
                         W[index_outputDim, I[index_selectedDim]] = Wb[index_selectedDim]
                     b[0, index_outputDim] = Wb[-1]


### PR DESCRIPTION
When we use a large number of voxels in decoding analysis, say hcpVC, the computation speed obviously decreases. One of the reasons is that the matrix indexing is not optimized. 
Here I slightly changed the way how the matrix is indexed. For a small number of voxels, the speed is not affected so much, but for a large number of voxels, I could observe 2~4 times faster speed depending on the machine.