### PR TITLE
Enable to save selected voxel, apply spatial normalization and select training sample

### DIFF
--- a/fastl2lir/fastl2lir.py
+++ b/fastl2lir/fastl2lir.py
@@ -102,7 +102,7 @@ class FastL2LiR(object):
             warnings.warn('X has less features than n_feat (X.shape[1] < n_feat). Feature selection is not applied.')
             no_feature_selection = True
 
-        # Save selected voxel mode
+        # # Save selected voxel mode
         if not save_select_feat:
             if (spatial_norm is not None) or (select_sample is not None):
                 save_select_feat = True
@@ -179,7 +179,6 @@ class FastL2LiR(object):
         -------
         Y : array_like
         '''
-
         if X.dtype != dtype: X = X.astype(dtype)
 
         # Save selected voxel mode
@@ -281,6 +280,8 @@ class FastL2LiR(object):
         """
         spatial_normalization ありの fitting を実行
         選択された voxel index を S に保存する
+        __sub_fit_save_select_feat から training sample selection 機能を除去したもの
+        現在未使用
         """
         if use_all_features:
             # Without feature selection                                      
@@ -335,8 +336,8 @@ class FastL2LiR(object):
                                 select_sample=None, 
                                 dtype=np.float64):
         """
-        unit ごとに 処理を実行
-        training sample の選抜が可能
+        Execute fitting for each unit
+        Enables spatial normalization for selected voxels and selection of training samples.
         """
         # Prepare the matixes to save.
         W = np.zeros((Y.shape[1], X.shape[1]), dtype=dtype) # feature size x voxel size
@@ -400,24 +401,23 @@ class FastL2LiR(object):
     def __apply_spatial_normalization(self, X, spatial_norm):
         """
         Perform the spatial normalization
-
         """
         if spatial_norm is None:
             pass
-        elif spatial_norm == "norm1": # L1norm
-            X = X / np.sum(np.abs(X), axis=1).reshape(X.shape[0], 1) # 行 sample ごとにL1normで割る
-        elif spatial_norm == "norm2": # L2norm
-            X = X / np.sqrt(np.sum(np.square(X), axis=1)).reshape(X.shape[0], 1)# 行 sample ごとにL2normで割る
-        elif spatial_norm == "std1": # STD=1で正規化
+        elif spatial_norm == "norm1": # L1norm (Divide by L1norm on each sample)
+            X = X / np.sum(np.abs(X), axis=1).reshape(X.shape[0], 1)
+        elif spatial_norm == "norm2": # L2norm (Divide by L2norm on each sample)
+            X = X / np.sqrt(np.sum(np.square(X), axis=1)).reshape(X.shape[0], 1)
+        elif spatial_norm == "std1": # Normalize with STD=1
             X = (X - np.mean(X, axis=1, keepdims=True)) / np.std(X, axis=1, ddof=1, keepdims=True) + np.mean(X, axis=1, keepdims=True)
-        elif spatial_norm == "std1mean0": # STD=1で正規化し，平均もさっぴく
+        elif spatial_norm == "std1mean0": # Mean correction + Normalize with STD=1
             X = (X - np.mean(X, axis=1, keepdims=True)) / np.std(X, axis=1, ddof=1, keepdims=True)
-        elif spatial_norm == "norm1mean0": # 平均補正のL1norm
+        elif spatial_norm == "norm1mean0": # Mean correction + L1norm (Divide by L1norm on each sample)
             X = X - np.mean(X, axis=1, keepdims=True)
-            X = X / np.sum(np.abs(X), axis=1).reshape(X.shape[0], 1) # 行 sample ごとにL1normで割る
-        elif spatial_norm == "norm2mean0": # 平均補正のL2norm
+            X = X / np.sum(np.abs(X), axis=1).reshape(X.shape[0], 1) 
+        elif spatial_norm == "norm2mean0": # Mean correction + L2norm (Divide by L2norm on each sample)
             X = X - np.mean(X, axis=1, keepdims=True)
-            X = X / np.sqrt(np.sum(np.square(X), axis=1)).reshape(X.shape[0], 1)# 行 sample ごとにL2normで割る
+            X = X / np.sqrt(np.sum(np.square(X), axis=1)).reshape(X.shape[0], 1)
         else:
             raise RuntimeError("Not implemented spatial normalization method:", spatial_norm)
         return X

--- a/fastl2lir/fastl2lir.py
+++ b/fastl2lir/fastl2lir.py
@@ -15,16 +15,14 @@ python_version = float('{}.{}'.format(pv.major, pv.minor))
 
 if python_version >= 3.5:
     from threadpoolctl import threadpool_limits
-print("python_version:", python_version)
+
 
 class FastL2LiR(object):
     '''Fast L2-regularized linear regression class.'''
 
-    def __init__(self, W=np.array([]), b=np.array([]), #S=np.array([]), 
-                 verbose=False):
+    def __init__(self, W=np.array([]), b=np.array([]), verbose=False):
         self.__W = W
         self.__b = b
-        #self.__S = S
         self.__verbose = verbose
 
     @property
@@ -81,10 +79,6 @@ class FastL2LiR(object):
         self
             Returns an instance of self.
         '''
-        print("alpha:", alpha)
-        print("n_feat:", n_feat)
-        print("spatial_norm:", spatial_norm)
-        print("select_sample:", select_sample)
 
         if X.dtype != dtype: X = X.astype(dtype)
         if Y.dtype != dtype: Y = Y.astype(dtype)
@@ -124,7 +118,6 @@ class FastL2LiR(object):
             for i, chunk in enumerate(chunks):
                 start_time = time()
                 if save_select_feat:
-                    print("Run sample selection mode.")
                     W, b, S = self.__sub_fit_save_select_feat(X, Y[0:, chunk], alpha=alpha, n_feat=n_feat, 
                                                            spatial_norm=spatial_norm, 
                                                            use_all_features=no_feature_selection, 
@@ -147,7 +140,6 @@ class FastL2LiR(object):
                 S = np.hstack(s_list)
         else:
             if save_select_feat:
-                print("Run sample selection mode.")
                 W, b, S = self.__sub_fit_save_select_feat(X, Y, alpha=alpha, n_feat=n_feat, 
                                                        spatial_norm=spatial_norm, 
                                                        use_all_features=no_feature_selection, 

--- a/readme.md
+++ b/readme.md
@@ -1,84 +1,40 @@
-# PyFastL2LiR_mtanaka
+# PyFastL2LiR: Fast L2-regularized Linear Regression
 
-[PyFastL2LiR](https://github.com/KamitaniLab/PyFastL2LiR) より下記の点が変更されている．
-
-- 各 unit に対して選択された voxel の index を保存する．
-- 選択された voxel のみを用いて sample 単位の spatial normalization が実行可能．
-- (branch relu_unitについて) 各 unit に対して使用する training sample の絞り込みが可能．
-
-使用時には `bdpy_mtanaka` リポジトリの bdpy を使用する必要がある．（データ保存形式が通常のbdpyと違うので必須）
-
-`bdpy_mtanaka`: https://github.com/KamitaniLab/bdpy_mtanaka
-
-
-## License
+[![PyPI version](https://badge.fury.io/py/fastl2lir.svg)](https://badge.fury.io/py/fastl2lir)
 [![GitHub license](https://img.shields.io/github/license/KamitaniLab/PyFastL2LiR)](https://github.com/KamitaniLab/PyFastL2LiR/blob/master/LICENSE)
 
+PyFastL2LR is fast implementation of ridge regression (regression with L2 normalization) that is developed for predicting neural netowrk unit activities from fMRI data. This method is five times faster than ordinary implementations of ridge regression, and can be used with feature selection.
 
-## Requiarements
-- Python >= 3.5
-- bdpy_mtanaka
-- threadpoolctl
+## Installation
+
+```
+$ pip install fastl2lir
+```
+
+When installing on Python >= 3.5, `threadpoolctl` are required.
 
 ## Usage
 
 ```
-import sys
-sys.path.insert(0, "./to_PyFasL2LiR_mtanaka")
-sys.path.insert(0, "./to_bdpy_mtanaka")
-
-import bdpy
-print(bdpy.__file__)
 import fastl2lir
-print(fastl2lir.__file__)
 
-from bdpy.ml import ModelTraining
-from fastl2lir import FastL2LiR
 
-# Training 
-makedir_ifnot('./tmp')
-distcomp_db = os.path.join('./tmp', analysis_basename + '.db')
-distcomp = DistComp(backend='sqlite3', db_path=distcomp_db)
-
-model = FastL2LiR()
-model_param = {
-    'alpha':  alpha,
-    'n_feat': num_voxel[roi],
-    'saveMemory': True, # 選択された voxel index を保存する
-    'sample_norm': 'norm2mean0', # sample に spatial normalization を適用する
-    'sample_selection': 'remove_nan', # training に使用する sample を基準に基づき選択する
-}
-train = ModelTraining(model, x, y)
-train.id = analysis_basename + '-' + sbj + '-' + roi + '-' + feat
-train.model_parameters = model_param
-train.X_normalize = {'mean': x_mean,
-                        'std': x_norm}
-train.Y_normalize = {'mean': y_mean,
-                        'std': y_norm}
-train.Y_sort = {'index': y_index}
-
-train.dtype = np.float32
-train.chunk_axis = chunk_axis
-train.save_format = 'bdmodel'
-train.save_path = results_dir
-train.distcomp = distcomp
-
-train.run()
-
-# Test
-test = ModelTest(model, x)
-test.model_format = 'bdmodel'
-test.model_path = model_dir
-test.model_parameters = {
-    'sample_norm': 'norm2mean0',
-    'use_feature_selector': True,
-    'saveMemory': True, # Training と同じ値を選択
-    'sample_norm': 'norm2mean0', # Training と同じ値を選択
-    #'sample_selection': 'remove_nan', # sample_selectionは不要 
-}
-test.dtype = np.float32
-test.chunk_axis = chunk_axis
-
-y_pred = test.run()
+model = fastl2lir.FastL2LiR()
+model.fit(X, Y, alpha, n_feat)
+Y_predicted = model.predict(X)
 ```
 
+Here,
+
+* `X`: A matrix (# of training samples x # of voxels).
+* `Y`: A vector including label information (# of training samples x # of cnn features).
+* `alpha`: Regularization term of L2 normalization.
+* `n_feat`: # of features to be selected (feature selection is based on correlation coefficient).
+
+See `demo.py` for more examples.
+
+## Notice
+
+* You don't need to add bias term in `X`; `FastL2LiR` automatically adds the bias term in the input data.
+* `FastL2LiR.fit()` automatically performs feature selection. You don't need to select features by yourself.
+* `X` and `Y` should be z-scored with mean and standard deviation of training data.

--- a/readme.md
+++ b/readme.md
@@ -1,40 +1,84 @@
-# PyFastL2LiR: Fast L2-regularized Linear Regression
+# PyFastL2LiR_mtanaka
 
-[![PyPI version](https://badge.fury.io/py/fastl2lir.svg)](https://badge.fury.io/py/fastl2lir)
+[PyFastL2LiR](https://github.com/KamitaniLab/PyFastL2LiR) より下記の点が変更されている．
+
+- 各 unit に対して選択された voxel の index を保存する．
+- 選択された voxel のみを用いて sample 単位の spatial normalization が実行可能．
+- (branch relu_unitについて) 各 unit に対して使用する training sample の絞り込みが可能．
+
+使用時には `bdpy_mtanaka` リポジトリの bdpy を使用する必要がある．（データ保存形式が通常のbdpyと違うので必須）
+
+`bdpy_mtanaka`: https://github.com/KamitaniLab/bdpy_mtanaka
+
+
+## License
 [![GitHub license](https://img.shields.io/github/license/KamitaniLab/PyFastL2LiR)](https://github.com/KamitaniLab/PyFastL2LiR/blob/master/LICENSE)
 
-PyFastL2LR is fast implementation of ridge regression (regression with L2 normalization) that is developed for predicting neural netowrk unit activities from fMRI data. This method is five times faster than ordinary implementations of ridge regression, and can be used with feature selection.
 
-## Installation
-
-```
-$ pip install fastl2lir
-```
-
-When installing on Python >= 3.5, `threadpoolctl` are required.
+## Requiarements
+- Python >= 3.5
+- bdpy_mtanaka
+- threadpoolctl
 
 ## Usage
 
 ```
+import sys
+sys.path.insert(0, "./to_PyFasL2LiR_mtanaka")
+sys.path.insert(0, "./to_bdpy_mtanaka")
+
+import bdpy
+print(bdpy.__file__)
 import fastl2lir
+print(fastl2lir.__file__)
 
+from bdpy.ml import ModelTraining
+from fastl2lir import FastL2LiR
 
-model = fastl2lir.FastL2LiR()
-model.fit(X, Y, alpha, n_feat)
-Y_predicted = model.predict(X)
+# Training 
+makedir_ifnot('./tmp')
+distcomp_db = os.path.join('./tmp', analysis_basename + '.db')
+distcomp = DistComp(backend='sqlite3', db_path=distcomp_db)
+
+model = FastL2LiR()
+model_param = {
+    'alpha':  alpha,
+    'n_feat': num_voxel[roi],
+    'saveMemory': True, # 選択された voxel index を保存する
+    'sample_norm': 'norm2mean0', # sample に spatial normalization を適用する
+    'sample_selection': 'remove_nan', # training に使用する sample を基準に基づき選択する
+}
+train = ModelTraining(model, x, y)
+train.id = analysis_basename + '-' + sbj + '-' + roi + '-' + feat
+train.model_parameters = model_param
+train.X_normalize = {'mean': x_mean,
+                        'std': x_norm}
+train.Y_normalize = {'mean': y_mean,
+                        'std': y_norm}
+train.Y_sort = {'index': y_index}
+
+train.dtype = np.float32
+train.chunk_axis = chunk_axis
+train.save_format = 'bdmodel'
+train.save_path = results_dir
+train.distcomp = distcomp
+
+train.run()
+
+# Test
+test = ModelTest(model, x)
+test.model_format = 'bdmodel'
+test.model_path = model_dir
+test.model_parameters = {
+    'sample_norm': 'norm2mean0',
+    'use_feature_selector': True,
+    'saveMemory': True, # Training と同じ値を選択
+    'sample_norm': 'norm2mean0', # Training と同じ値を選択
+    #'sample_selection': 'remove_nan', # sample_selectionは不要 
+}
+test.dtype = np.float32
+test.chunk_axis = chunk_axis
+
+y_pred = test.run()
 ```
 
-Here,
-
-* `X`: A matrix (# of training samples x # of voxels).
-* `Y`: A vector including label information (# of training samples x # of cnn features).
-* `alpha`: Regularization term of L2 normalization.
-* `n_feat`: # of features to be selected (feature selection is based on correlation coefficient).
-
-See `demo.py` for more examples.
-
-## Notice
-
-* You don't need to add bias term in `X`; `FastL2LiR` automatically adds the bias term in the input data.
-* `FastL2LiR.fit()` automatically performs feature selection. You don't need to select features by yourself.
-* `X` and `Y` should be z-scored with mean and standard deviation of training data.


### PR DESCRIPTION
unitごとに選択したvoxelを記録するS.matを保存するモード"save_select_feat"を追加しました．
そもそもこれを実装する理由であった"spatial_norm"による空間的正規化の機能も実装されています．
またtraining sampleの選択モードも追加しています．
S.matの保存はbdpy側で行われているため，bdpy側の更新（spatial_normブランチ）を同時に行う必要があります．