### PR TITLE
Fix reversed primal-dual selection condition

### DIFF
--- a/src/fastl2lir/fastl2lir.py
+++ b/src/fastl2lir/fastl2lir.py
@@ -244,11 +244,11 @@ class FastL2LiR(object):
             
             # Choose the more efficient method based on matrix dimensions
             if X.shape[0] > X.shape[1]:
-                # Use dual form for tall matrices (more samples than features)
-                Wb = np.matmul(X.T, np.linalg.solve(np.matmul(X, X.T) + alpha * np.eye(X.shape[0], dtype=dtype), Y))
-            else:
-                # Use primal form for wide matrices (more features than samples)
+                # Use primal form for tall matrices (more samples than features)
                 Wb = np.linalg.solve(np.matmul(X.T, X) + alpha * np.eye(X.shape[1], dtype=dtype), np.matmul(X.T, Y))
+            else:
+                # Use dual form for wide matrices (more features than samples)
+                Wb = np.matmul(X.T, np.linalg.solve(np.matmul(X, X.T) + alpha * np.eye(X.shape[0], dtype=dtype), Y))
             
             W = Wb[0:-1, :]
             b = Wb[-1, :][np.newaxis, :]  # Returning b as a 2D array


### PR DESCRIPTION
This PR fixes the primal/dual solver selection condition introduced in #7.

The previous implementation selected the formulation with the larger computational cost:
- It used the dual form when `n_samples > n_features`.
- It used the primal form otherwise.

This PR reverses the condition so that the solver now selects the formulation with the smaller matrix to solve:
- Use the primal form when `n_samples > n_features`.
- Use the dual form otherwise.

### Checks

Following `CONTRIBUTING.md`, I confirmed that `pytest` passes.

I also ran `ruff check .`, but it reported many existing linting errors. Since fixing those errors is outside the scope of this PR, I did not address them here.