### PR TITLE
Add solver option and add scipy solver backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
     "numpy>=1.22.0",
-    "scipy>=1.2.3",
+    "scipy>=1.8",
     "threadpoolctl>=2.1.0",
     "tqdm>=4.64.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
     "numpy>=1.22.0",
+    "scipy>=1.2.3",
     "threadpoolctl>=2.1.0",
     "tqdm>=4.64.1",
 ]

--- a/src/fastl2lir/fastl2lir.py
+++ b/src/fastl2lir/fastl2lir.py
@@ -22,7 +22,10 @@ class FastL2LiR(object):
         # Choose linear solver once to avoid branching at call sites
         if solver == 'scipy':
             def _solve(a, b):
-                return sp_linalg.solve(a, b, assume_a='sym', check_finite=False)
+                try:
+                    return sp_linalg.solve(a, b, assume_a='pos', check_finite=False)
+                except sp_linalg.LinAlgError:
+                    return sp_linalg.solve(a, b, assume_a='sym', check_finite=False)
         elif solver == 'numpy':
             def _solve(a, b):
                 return np.linalg.solve(a, b)

--- a/src/fastl2lir/fastl2lir.py
+++ b/src/fastl2lir/fastl2lir.py
@@ -13,24 +13,26 @@ from scipy import linalg as sp_linalg
 class FastL2LiR(object):
     """Fast L2-regularized linear regression class."""
 
-    def __init__(self, W=np.array([]), b=np.array([]), verbose=False, solver='scipy'):
+    def __init__(self, W=np.array([]), b=np.array([]), verbose=False, solver="scipy"):
         self.__W = W
         self.__b = b
         self.__verbose = verbose
         self.__solver = solver
 
         # Choose linear solver once to avoid branching at call sites
-        if solver == 'scipy':
+        if solver == "scipy":
+
             def _solve(a, b):
                 try:
-                    return sp_linalg.solve(a, b, assume_a='pos', check_finite=False)
+                    return sp_linalg.solve(a, b, assume_a="pos", check_finite=False)
                 except sp_linalg.LinAlgError:
-                    return sp_linalg.solve(a, b, assume_a='sym', check_finite=False)
-        elif solver == 'numpy':
+                    return sp_linalg.solve(a, b, assume_a="sym", check_finite=False)
+        elif solver == "numpy":
+
             def _solve(a, b):
                 return np.linalg.solve(a, b)
         else:
-            raise ValueError('Unknown solver: %s' % solver)
+            raise ValueError("Unknown solver: %s" % solver)
         self.__solve = _solve
 
     @property

--- a/src/fastl2lir/fastl2lir.py
+++ b/src/fastl2lir/fastl2lir.py
@@ -21,6 +21,14 @@ def _solve_numpy(a, b):
     return np.linalg.solve(a, b)
 
 
+def _get_solver_func(solver):
+    if solver == "scipy":
+        return _solve_scipy
+    if solver == "numpy":
+        return _solve_numpy
+    raise ValueError(f"Unknown solver: {solver!r}. Expected one of: 'scipy', 'numpy'.")
+
+
 class FastL2LiR(object):
     """Fast L2-regularized linear regression class."""
 
@@ -28,15 +36,26 @@ class FastL2LiR(object):
         self.__W = W
         self.__b = b
         self.__verbose = verbose
+        self.__solver = solver
+        self.__solve = _get_solver_func(solver)
 
-        if solver == "scipy":
-            self.__solve = _solve_scipy
-        elif solver == "numpy":
-            self.__solve = _solve_numpy
-        else:
-            raise ValueError(
-                f"Unknown solver: {solver!r}. Expected one of: 'scipy', 'numpy'."
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state.pop("_FastL2LiR__solve", None)
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        solver_key = "_FastL2LiR__solver"
+        if solver_key not in self.__dict__:
+            warnings.warn(
+                "Unpickled a FastL2LiR object without solver information. "
+                "Restoring it with solver='numpy' for backward compatibility.",
+                UserWarning,
+                stacklevel=2,
             )
+            self.__dict__[solver_key] = "numpy"
+        self.__solve = _get_solver_func(self.__dict__[solver_key])
 
     @property
     def W(self):

--- a/src/fastl2lir/fastl2lir.py
+++ b/src/fastl2lir/fastl2lir.py
@@ -32,7 +32,9 @@ class FastL2LiR(object):
             def _solve(a, b):
                 return np.linalg.solve(a, b)
         else:
-            raise ValueError("Unknown solver: %s" % solver)
+            raise ValueError(
+                f"Unknown solver: {solver!r}. Expected one of: 'scipy', 'numpy'."
+            )
         self.__solve = _solve
 
     @property

--- a/src/fastl2lir/fastl2lir.py
+++ b/src/fastl2lir/fastl2lir.py
@@ -10,6 +10,17 @@ from tqdm import tqdm
 from scipy import linalg as sp_linalg
 
 
+def _solve_scipy(a, b):
+    try:
+        return sp_linalg.solve(a, b, assume_a="pos", check_finite=False)
+    except sp_linalg.LinAlgError:
+        return sp_linalg.solve(a, b, assume_a="sym", check_finite=False)
+
+
+def _solve_numpy(a, b):
+    return np.linalg.solve(a, b)
+
+
 class FastL2LiR(object):
     """Fast L2-regularized linear regression class."""
 
@@ -17,25 +28,15 @@ class FastL2LiR(object):
         self.__W = W
         self.__b = b
         self.__verbose = verbose
-        self.__solver = solver
 
-        # Choose linear solver once to avoid branching at call sites
         if solver == "scipy":
-
-            def _solve(a, b):
-                try:
-                    return sp_linalg.solve(a, b, assume_a="pos", check_finite=False)
-                except sp_linalg.LinAlgError:
-                    return sp_linalg.solve(a, b, assume_a="sym", check_finite=False)
+            self.__solve = _solve_scipy
         elif solver == "numpy":
-
-            def _solve(a, b):
-                return np.linalg.solve(a, b)
+            self.__solve = _solve_numpy
         else:
             raise ValueError(
                 f"Unknown solver: {solver!r}. Expected one of: 'scipy', 'numpy'."
             )
-        self.__solve = _solve
 
     @property
     def W(self):

--- a/src/fastl2lir/fastl2lir.py
+++ b/src/fastl2lir/fastl2lir.py
@@ -7,15 +7,28 @@ import warnings
 import numpy as np
 from threadpoolctl import threadpool_limits
 from tqdm import tqdm
+from scipy import linalg as sp_linalg
 
 
 class FastL2LiR(object):
     """Fast L2-regularized linear regression class."""
 
-    def __init__(self, W=np.array([]), b=np.array([]), verbose=False):
+    def __init__(self, W=np.array([]), b=np.array([]), verbose=False, solver='scipy'):
         self.__W = W
         self.__b = b
         self.__verbose = verbose
+        self.__solver = solver
+
+        # Choose linear solver once to avoid branching at call sites
+        if solver == 'scipy':
+            def _solve(a, b):
+                return sp_linalg.solve(a, b, assume_a='sym', check_finite=False)
+        elif solver == 'numpy':
+            def _solve(a, b):
+                return np.linalg.solve(a, b)
+        else:
+            raise ValueError('Unknown solver: %s' % solver)
+        self.__solve = _solve
 
     @property
     def W(self):
@@ -271,7 +284,7 @@ class FastL2LiR(object):
             # Choose the more efficient method based on matrix dimensions
             if X.shape[0] > X.shape[1]:
                 # Use primal form for tall matrices (more samples than features)
-                Wb = np.linalg.solve(
+                Wb = self.__solve(
                     np.matmul(X.T, X) + alpha * np.eye(X.shape[1], dtype=dtype),
                     np.matmul(X.T, Y),
                 )
@@ -279,11 +292,10 @@ class FastL2LiR(object):
                 # Use dual form for wide matrices (more features than samples)
                 Wb = np.matmul(
                     X.T,
-                    np.linalg.solve(
+                    self.__solve(
                         np.matmul(X, X.T) + alpha * np.eye(X.shape[0], dtype=dtype), Y
                     ),
                 )
-
             W = Wb[0:-1, :]
             b = Wb[-1, :][np.newaxis, :]  # Returning b as a 2D array
         else:
@@ -312,7 +324,7 @@ class FastL2LiR(object):
                             ).ravel()
                         ]
                     ).reshape(feat_idx.size, feat_idx.size)
-                    Wb = np.linalg.solve(W0_sub, W1[index_outputDim, feat_idx])
+                    Wb = self.__solve(W0_sub, W1[index_outputDim, feat_idx])
                     W[index_outputDim, feat_idx[:-1]] = Wb[:-1]
                     b[0, index_outputDim] = Wb[-1]
                 W = W.T
@@ -379,7 +391,7 @@ class FastL2LiR(object):
                     newX.shape[1], dtype=dtype
                 )
                 rhs = np.matmul(selY.ravel(), newX)
-                Wb = np.linalg.solve(W0, rhs)
+                Wb = self.__solve(W0, rhs)
                 W[index_outputDim, feat_idx] = Wb[:-1]
                 b[0, index_outputDim] = Wb[-1]
             W = W.T

--- a/src/fastl2lir/fastl2lir.py
+++ b/src/fastl2lir/fastl2lir.py
@@ -32,7 +32,7 @@ def _get_solver_func(solver):
 class FastL2LiR(object):
     """Fast L2-regularized linear regression class."""
 
-    def __init__(self, W=np.array([]), b=np.array([]), verbose=False, solver="scipy"):
+    def __init__(self, W=np.array([]), b=np.array([]), verbose=False, solver="numpy"):
         self.__W = W
         self.__b = b
         self.__verbose = verbose

--- a/tests/test_fastl2lir.py
+++ b/tests/test_fastl2lir.py
@@ -149,6 +149,22 @@ class TestFastL2LiR(TestCase):
         np.testing.assert_array_almost_equal(model_numpy.W, model_scipy.W)
         np.testing.assert_array_almost_equal(model_numpy.b, model_scipy.b)
 
+    def test_solver_helpers_agree(self):
+        """FastL2LiR's numpy and scipy solvers agree on the same linear system."""
+        rng = np.random.default_rng(0)
+        n = 50
+        A = rng.standard_normal((n, n))
+        A = A.T @ A + np.eye(n)  # symmetric positive definite
+        b = rng.standard_normal((n, 10))
+
+        model_numpy = fastl2lir.FastL2LiR(solver="numpy")
+        model_scipy = fastl2lir.FastL2LiR(solver="scipy")
+
+        result_numpy = model_numpy._FastL2LiR__solve(A, b)
+        result_scipy = model_scipy._FastL2LiR__solve(A, b)
+
+        np.testing.assert_array_almost_equal(result_numpy, result_scipy)
+
     def test_solver_pickle(self):
         """FastL2LiR instance with scipy solver can be pickled and unpickled."""
         import pickle

--- a/tests/test_fastl2lir.py
+++ b/tests/test_fastl2lir.py
@@ -137,22 +137,22 @@ class TestFastL2LiR(TestCase):
         np.testing.assert_array_almost_equal(yp_2d, data["yp_2d"])
 
     def test_solver_numpy_matches_scipy(self):
-        '''numpy solver produces same result as scipy solver (default).'''
-        data = np.load('./tests/testdata_basic.npz')
+        """numpy solver produces same result as scipy solver (default)."""
+        data = np.load("./tests/testdata_basic.npz")
 
-        model_scipy = fastl2lir.FastL2LiR(solver='scipy')
-        model_numpy = fastl2lir.FastL2LiR(solver='numpy')
+        model_scipy = fastl2lir.FastL2LiR(solver="scipy")
+        model_numpy = fastl2lir.FastL2LiR(solver="numpy")
 
-        model_scipy.fit(data['x_tr'], data['y_2d'])
-        model_numpy.fit(data['x_tr'], data['y_2d'])
+        model_scipy.fit(data["x_tr"], data["y_2d"])
+        model_numpy.fit(data["x_tr"], data["y_2d"])
 
         np.testing.assert_array_almost_equal(model_numpy.W, model_scipy.W)
         np.testing.assert_array_almost_equal(model_numpy.b, model_scipy.b)
 
     def test_solver_invalid(self):
-        '''Invalid solver name raises ValueError.'''
+        """Invalid solver name raises ValueError."""
         with self.assertRaises(ValueError):
-            fastl2lir.FastL2LiR(solver='cholesky')
+            fastl2lir.FastL2LiR(solver="cholesky")
 
     def test_reshape(self):
         """Test for reshaping."""
@@ -172,12 +172,11 @@ class TestFastL2LiR(TestCase):
         np.testing.assert_array_equal(model_test.b.shape, (1,) + Y_shape[1:])
         np.testing.assert_array_equal(pred_test.shape, Y_shape)
 
-
     def test_save_select_feat_default_select_sample(self):
-        '''save_select_feat=True with default select_sample=None should not raise.'''
-        data = np.load('./tests/testdata_nfeat.npz')
+        """save_select_feat=True with default select_sample=None should not raise."""
+        data = np.load("./tests/testdata_nfeat.npz")
         model = fastl2lir.FastL2LiR()
-        model.fit(data['x_tr'], data['y_1d'], n_feat=20, save_select_feat=True)
+        model.fit(data["x_tr"], data["y_1d"], n_feat=20, save_select_feat=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_fastl2lir.py
+++ b/tests/test_fastl2lir.py
@@ -149,6 +149,29 @@ class TestFastL2LiR(TestCase):
         np.testing.assert_array_almost_equal(model_numpy.W, model_scipy.W)
         np.testing.assert_array_almost_equal(model_numpy.b, model_scipy.b)
 
+    def test_solver_pickle(self):
+        """FastL2LiR instance with scipy solver can be pickled and unpickled."""
+        import pickle
+
+        data = np.load("./tests/testdata_basic.npz")
+        model = fastl2lir.FastL2LiR(solver="scipy")
+        model.fit(data["x_tr"], data["y_2d"])
+        restored = pickle.loads(pickle.dumps(model))
+        np.testing.assert_array_almost_equal(model.W, restored.W)
+        np.testing.assert_array_almost_equal(model.b, restored.b)
+
+    def test_solver_scipy_fallback(self):
+        """scipy solver falls back from assume_a='pos' to 'sym' for indefinite matrix."""
+        from fastl2lir.fastl2lir import _solve_scipy
+
+        n = 20
+        rng = np.random.default_rng(0)
+        A = np.diag([1.0] * (n - 1) + [-1.0])
+        b = rng.standard_normal((n, 5))
+        result = _solve_scipy(A, b)
+        residual = np.linalg.norm(A @ result - b) / np.linalg.norm(b)
+        self.assertLess(residual, 1e-10)
+
     def test_solver_invalid(self):
         """Invalid solver name raises ValueError."""
         with self.assertRaises(ValueError):

--- a/tests/test_fastl2lir.py
+++ b/tests/test_fastl2lir.py
@@ -136,6 +136,24 @@ class TestFastL2LiR(TestCase):
 
         np.testing.assert_array_almost_equal(yp_2d, data["yp_2d"])
 
+    def test_solver_numpy_matches_scipy(self):
+        '''numpy solver produces same result as scipy solver (default).'''
+        data = np.load('./tests/testdata_basic.npz')
+
+        model_scipy = fastl2lir.FastL2LiR(solver='scipy')
+        model_numpy = fastl2lir.FastL2LiR(solver='numpy')
+
+        model_scipy.fit(data['x_tr'], data['y_2d'])
+        model_numpy.fit(data['x_tr'], data['y_2d'])
+
+        np.testing.assert_array_almost_equal(model_numpy.W, model_scipy.W)
+        np.testing.assert_array_almost_equal(model_numpy.b, model_scipy.b)
+
+    def test_solver_invalid(self):
+        '''Invalid solver name raises ValueError.'''
+        with self.assertRaises(ValueError):
+            fastl2lir.FastL2LiR(solver='cholesky')
+
     def test_reshape(self):
         """Test for reshaping."""
         Y_shape = (200, 10, 10, 5)

--- a/tests/test_fastl2lir.py
+++ b/tests/test_fastl2lir.py
@@ -150,20 +150,16 @@ class TestFastL2LiR(TestCase):
         np.testing.assert_array_almost_equal(model_numpy.b, model_scipy.b)
 
     def test_solver_helpers_agree(self):
-        """FastL2LiR's numpy and scipy solvers agree on the same linear system."""
+        """_solve_numpy and _solve_scipy return the same result."""
+        from fastl2lir.fastl2lir import _solve_numpy, _solve_scipy
+
         rng = np.random.default_rng(0)
         n = 50
         A = rng.standard_normal((n, n))
-        A = A.T @ A + np.eye(n)  # symmetric positive definite
+        A = A.T @ A + np.eye(n)
         b = rng.standard_normal((n, 10))
 
-        model_numpy = fastl2lir.FastL2LiR(solver="numpy")
-        model_scipy = fastl2lir.FastL2LiR(solver="scipy")
-
-        result_numpy = model_numpy._FastL2LiR__solve(A, b)
-        result_scipy = model_scipy._FastL2LiR__solve(A, b)
-
-        np.testing.assert_array_almost_equal(result_numpy, result_scipy)
+        np.testing.assert_array_almost_equal(_solve_numpy(A, b), _solve_scipy(A, b))
 
     def test_solver_pickle(self):
         """FastL2LiR instance with scipy solver can be pickled and unpickled."""
@@ -175,6 +171,30 @@ class TestFastL2LiR(TestCase):
         restored = pickle.loads(pickle.dumps(model))
         np.testing.assert_array_almost_equal(model.W, restored.W)
         np.testing.assert_array_almost_equal(model.b, restored.b)
+        np.testing.assert_array_almost_equal(
+            model.predict(data["x_te"]), restored.predict(data["x_te"])
+        )
+
+    def test_solver_getstate(self):
+        """__getstate__ does not store the solver function."""
+        model = fastl2lir.FastL2LiR(solver="scipy")
+        state = model.__getstate__()
+        self.assertNotIn("_FastL2LiR__solve", state)
+        self.assertEqual(state["_FastL2LiR__solver"], "scipy")
+
+    def test_solver_legacy_setstate(self):
+        """__setstate__ falls back to numpy for legacy pickles without solver info."""
+        model = fastl2lir.FastL2LiR.__new__(fastl2lir.FastL2LiR)
+        legacy_state = {
+            "_FastL2LiR__W": np.array([]),
+            "_FastL2LiR__b": np.array([]),
+            "_FastL2LiR__verbose": False,
+        }
+        with self.assertWarns(UserWarning):
+            model.__setstate__(legacy_state)
+        self.assertEqual(model._FastL2LiR__solver, "numpy")
+        data = np.load("./tests/testdata_basic.npz")
+        model.fit(data["x_tr"], data["y_2d"])
 
     def test_solver_scipy_fallback(self):
         """scipy solver falls back from assume_a='pos' to 'sym' for indefinite matrix."""


### PR DESCRIPTION
This PR adds a `solver` option to `FastL2LiR`. The default solver remains `numpy` (`np.linalg.solve`), and `scipy` is available as an option.

Previously, `FastL2LiR` used `np.linalg.solve` to solve the normal equations. This treats the coefficient matrix as a general dense matrix. The new `solver="scipy"` option uses `scipy.linalg.solve` with `assume_a="pos"`, which allows SciPy to use a Cholesky-based solver.

The speedup from the SciPy solver depends heavily on the environment. In single-threaded environments without SIMD optimization (e.g., RISC-V), a speedup of around 3x was observed. In multi-threaded x86 environments with AVX-512, the difference is negligible.

### Changes

1. Added a `solver` option (`"numpy"` or `"scipy"`).
2. Added tests for the solver option.

### Checks

Following `CONTRIBUTING.md`, I confirmed that `pytest` passes.

I also ran `ruff check .` and `ruff format .`, and all checks pass.

### Note

The `assume_a="pos"` solver may fail when the coefficient matrix has a large condition number. In such cases, the implementation falls back to `assume_a="sym"`.

However, even with `assume_a="sym"` or the previous `np.linalg.solve`-based implementation, there is no guarantee that a good numerical solution is obtained in such cases.

A large condition number can occur when `alpha=0` or when `alpha` is very small. In particular, when `alpha=0`, returning an OLS estimator would be another possible implementation, but this PR does not address it because it would be a behavior change.