### PR TITLE
fix: NumPy 2.4+ compatibility in feature selection fitting paths

### DIFF
--- a/src/fastl2lir/fastl2lir.py
+++ b/src/fastl2lir/fastl2lir.py
@@ -274,9 +274,8 @@ class FastL2LiR(object):
                         I = I[0:n_feat]
                         I = np.hstack((I, X.shape[1]-1))
                         W0_sub = (W0.ravel()[(I + (I * W0.shape[1]).reshape((-1, 1))).ravel()]).reshape(I.size, I.size)
-                        Wb = np.linalg.solve(W0_sub, W1[index_outputDim][I].reshape(-1, 1))
-                        for index_selectedDim in range(n_feat):
-                            W[index_outputDim, I[index_selectedDim]] = Wb[index_selectedDim]
+                        Wb = np.linalg.solve(W0_sub, W1[index_outputDim, I])
+                        W[index_outputDim, I[:-1]] = Wb[:-1]
                         b[0, index_outputDim] = Wb[-1]
                     W = W.T
             else:
@@ -287,9 +286,8 @@ class FastL2LiR(object):
                     I = I[0:n_feat]
                     I = np.hstack((I, X.shape[1]-1))
                     W0_sub = (W0.ravel()[(I + (I * W0.shape[1]).reshape((-1,1))).ravel()]).reshape(I.size, I.size)
-                    Wb = np.linalg.solve(W0_sub, W1[index_outputDim][I].reshape(-1,1))
-                    for index_selectedDim in range(n_feat):
-                        W[index_outputDim, I[index_selectedDim]] = Wb[index_selectedDim]
+                    Wb = np.linalg.solve(W0_sub, W1[index_outputDim, I])
+                    W[index_outputDim, I[:-1]] = Wb[:-1]
                     b[0, index_outputDim] = Wb[-1]
                 W = W.T
 
@@ -310,7 +308,7 @@ class FastL2LiR(object):
         # Prepare the matixes to save.
         W = np.zeros((Y.shape[1], X.shape[1]), dtype=dtype)    # feature size x voxel size
         b = np.zeros((1, Y.shape[1]), dtype=dtype)             # feautre size
-        S = np.zeros((Y.shape[1], X.shape[1]), dtype=np.bool)  # feature size x voxel size
+        S = np.zeros((Y.shape[1], X.shape[1]), dtype=np.bool_)  # feature size x voxel size
 
         if not (pv.major > 3 or (pv.major == 3 and pv.minor >= 5)):
             raise RuntimeError('Python version requires 3.5 or more.')
@@ -343,13 +341,12 @@ class FastL2LiR(object):
                 # Fit
                 newX = np.hstack((newX, np.ones((newX.shape[0], 1), dtype=dtype)))  # Add one column to rightmost column
                 W0 = np.matmul(newX.T, newX) + alpha * np.eye(newX.shape[1], dtype=dtype)
-                W1 = np.matmul(selY.ravel(), newX).reshape(-1,1)
-                Wb = np.linalg.solve(W0, W1)
-                for index_selectedDim in range(n_feat):
-                    W[index_outputDim, I[index_selectedDim]] = Wb[index_selectedDim]
+                rhs = np.matmul(selY.ravel(), newX)
+                Wb = np.linalg.solve(W0, rhs)
+                W[index_outputDim, I] = Wb[:-1]
                 b[0, index_outputDim] = Wb[-1]
             W = W.T
-            S = np.asarray(S.T, dtype=np.bool)  # Transpose and convert to bool type
+            S = np.asarray(S.T, dtype=np.bool_)  # Transpose and convert to bool type
 
         return W, b, S
 


### PR DESCRIPTION
## Summary

Fix NumPy 2.4+ compatibility issues in the feature-selection fitting paths of `src/fastl2lir/fastl2lir.py`.

## Background

In the feature-selection paths of `__sub_fit` and `__sub_fit_save_select_feat`, the right-hand side passed to `np.linalg.solve()` was reshaped to a column vector using `.reshape(-1, 1)`.

As a result, the solution `Wb` also became a 2D column vector. Expressions such as `Wb[i]` therefore returned a length-1 array rather than a scalar. Assigning such a length-1 array to a scalar element of `W` or `b` was deprecated in NumPy 1.25 and raises a `TypeError` in NumPy 2.4+.

## Changes

* In `__sub_fit`, update both feature-selection branches to pass a 1D RHS to `np.linalg.solve()`.
* Replace the per-feature assignment loop with a vectorized assignment:

  ```python
  W[index_outputDim, I[:-1]] = Wb[:-1]
  ```
* In `__sub_fit_save_select_feat`, apply the same 1D-RHS pattern and replace the assignment loop with:

  ```python
  W[index_outputDim, I] = Wb[:-1]
  ```
* Replace `dtype=np.bool` with `dtype=np.bool_` for compatibility with NumPy versions where `np.bool` was removed.

The no-feature-selection multi-target solve path in `__sub_fit` is left unchanged, since that path intentionally solves a multi-target system.

## Tests

I ran the following tests and confirmed that all tests pass, including with NumPy deprecation warnings treated as errors:

```bash
uv run pytest                               # 7 passed
uv run pytest -W error::DeprecationWarning   # 7 passed
