### PR TITLE
drop python 3.9 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ PyFastL2LR is fast implementation of ridge regression (regression with L2 normal
 $ pip install fastl2lir
 ```
 
-When installing on Python >= 3.5, `threadpoolctl` are required.
-
 ## Usage
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ maintainers = [
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
-    "numpy>=1.16.6",
+    "numpy>=1.22.0",
     "threadpoolctl>=2.1.0",
     "tqdm>=4.64.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,10 @@ maintainers = [
     { name = "Yoshihiro Nagano", email = "kamitanilab@gmail.com" }
 ]
 license = { file = "LICENSE" }
-requires-python = ">=3.1"
+requires-python = ">=3.10"
 dependencies = [
     "numpy>=1.16.6",
-    "threadpoolctl>=2.1.0 ; python_full_version >= '3.5'",
+    "threadpoolctl>=2.1.0",
     "tqdm>=4.64.1",
 ]
 [project.urls]

--- a/src/fastl2lir/fastl2lir.py
+++ b/src/fastl2lir/fastl2lir.py
@@ -2,17 +2,12 @@
 
 
 import math
-import sys
 from time import time
 import warnings
 
 import numpy as np
+from threadpoolctl import threadpool_limits
 from tqdm import tqdm
-
-pv = sys.version_info
-
-if pv.major > 3 or (pv.major == 3 and pv.minor >= 5):
-    from threadpoolctl import threadpool_limits
 
 
 class FastL2LiR(object):
@@ -264,28 +259,14 @@ class FastL2LiR(object):
             W1 = np.matmul(Y.T, X)
             C = C.T
 
-            # TODO: refactoring
-            if pv.major > 3 or (pv.major == 3 and pv.minor >= 5):
-                with threadpool_limits(limits=1, user_api='blas'):
-                    for index_outputDim in tqdm(range(Y.shape[1])):
-                        C0 = abs(C[index_outputDim,:])
-                        I = np.argsort(C0)
-                        I = I[::-1]
-                        I = I[0:n_feat]
-                        I = np.hstack((I, X.shape[1]-1))
-                        W0_sub = (W0.ravel()[(I + (I * W0.shape[1]).reshape((-1, 1))).ravel()]).reshape(I.size, I.size)
-                        Wb = np.linalg.solve(W0_sub, W1[index_outputDim, I])
-                        W[index_outputDim, I[:-1]] = Wb[:-1]
-                        b[0, index_outputDim] = Wb[-1]
-                    W = W.T
-            else:
+            with threadpool_limits(limits=1, user_api='blas'):
                 for index_outputDim in tqdm(range(Y.shape[1])):
                     C0 = abs(C[index_outputDim,:])
                     I = np.argsort(C0)
                     I = I[::-1]
                     I = I[0:n_feat]
                     I = np.hstack((I, X.shape[1]-1))
-                    W0_sub = (W0.ravel()[(I + (I * W0.shape[1]).reshape((-1,1))).ravel()]).reshape(I.size, I.size)
+                    W0_sub = (W0.ravel()[(I + (I * W0.shape[1]).reshape((-1, 1))).ravel()]).reshape(I.size, I.size)
                     Wb = np.linalg.solve(W0_sub, W1[index_outputDim, I])
                     W[index_outputDim, I[:-1]] = Wb[:-1]
                     b[0, index_outputDim] = Wb[-1]
@@ -309,9 +290,6 @@ class FastL2LiR(object):
         W = np.zeros((Y.shape[1], X.shape[1]), dtype=dtype)    # feature size x voxel size
         b = np.zeros((1, Y.shape[1]), dtype=dtype)             # feautre size
         S = np.zeros((Y.shape[1], X.shape[1]), dtype=np.bool_)  # feature size x voxel size
-
-        if not (pv.major > 3 or (pv.major == 3 and pv.minor >= 5)):
-            raise RuntimeError('Python version requires 3.5 or more.')
 
         with threadpool_limits(limits=1, user_api='blas'):
             for index_outputDim in tqdm(range(Y.shape[1])):


### PR DESCRIPTION
## Summary

Drops support for Python 3.9 and below, setting Python 3.10 as the new minimum version.

## Changes

- Set `requires-python = ">=3.10"` and bump `numpy` minimum to `1.22.0` (first release with Python 3.10 wheels)
- Remove `threadpoolctl` conditional dependency marker
- Remove Python version detection and pre-3.5 fallback code from `fastl2lir.py`
- Remove outdated `threadpoolctl` installation note from README

## Checks
Following `CONTRIBUTING.md`, I confirmed that `pytest` passes.

I also ran `ruff check .`, but it reported many existing linting errors. Since fixing those errors is outside the scope of this PR, I did not address them here.