### PR TITLE
fix: initialize selector for all samples when select_sample is None

### DIFF
--- a/src/fastl2lir/fastl2lir.py
+++ b/src/fastl2lir/fastl2lir.py
@@ -295,7 +295,7 @@ class FastL2LiR(object):
             for index_outputDim in tqdm(range(Y.shape[1])):
                 # Select training samples
                 if select_sample is None:
-                    pass
+                    selector = np.ones(Y.shape[0], dtype=np.bool_)
                 elif select_sample == 'remove_nan':  # Delete sample with nan value in unit
                     selector = np.logical_not(np.isnan(Y[:, index_outputDim].flatten()))
                 else:

--- a/src/fastl2lir/fastl2lir.py
+++ b/src/fastl2lir/fastl2lir.py
@@ -295,7 +295,7 @@ class FastL2LiR(object):
             for index_outputDim in tqdm(range(Y.shape[1])):
                 # Select training samples
                 if select_sample is None:
-                    selector = np.ones(Y.shape[0], dtype=np.bool_)
+                    selector = slice(None)
                 elif select_sample == 'remove_nan':  # Delete sample with nan value in unit
                     selector = np.logical_not(np.isnan(Y[:, index_outputDim].flatten()))
                 else:

--- a/tests/test_fastl2lir.py
+++ b/tests/test_fastl2lir.py
@@ -158,6 +158,13 @@ class TestFastL2LiR(TestCase):
         np.testing.assert_array_equal(pred_test.shape, Y_shape)
 
 
+    def test_save_select_feat_default_select_sample(self):
+        '''save_select_feat=True with default select_sample=None should not raise.'''
+        data = np.load('./tests/testdata_nfeat.npz')
+        model = fastl2lir.FastL2LiR()
+        model.fit(data['x_tr'], data['y_1d'], n_feat=20, save_select_feat=True)
+
+
 if __name__ == "__main__":
     test_suite = TestLoader().loadTestsFromTestCase(TestFastL2LiR)
     TextTestRunner(verbosity=2).run(test_suite)


### PR DESCRIPTION
This PR fixes an `UnboundLocalError` that occurred when fitting with `save_select_feat=True` and the default `select_sample=None`.

Changes:

- In `__sub_fit_save_select_feat`, `selector` was not assigned when `select_sample=None`, causing an `UnboundLocalError` when `save_select_feat=True` or `spatial_norm` was specified.
- Set `selector = slice(None)` in the default case to select all samples without creating an unnecessary copy of `X`.

- Add regression test for this bug

## Testing

Added a regression test (`test_save_select_feat_default_select_sample`).
All tests pass (`pytest`).